### PR TITLE
Trimming samples

### DIFF
--- a/Xcode/SmartSensors/SmartSensors.xcodeproj/project.pbxproj
+++ b/Xcode/SmartSensors/SmartSensors.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		3016C29D8E0735FBAEF55DFA /* ofxGrtTimeseriesPlot.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 30; name = ofxGrtTimeseriesPlot.cpp; path = "../../third-party/openFrameworks/addons/ofxGrt/src/ofxGrtTimeseriesPlot.cpp"; sourceTree = SOURCE_ROOT; };
 		33590F0CD7DAD6FE90515E35 /* ofxGuiGroup.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxGuiGroup.h; path = "../../third-party/openFrameworks/addons/ofxGui/src/ofxGuiGroup.h"; sourceTree = SOURCE_ROOT; };
 		33AE35DBE2EBE926124EFA8A /* ofxGui.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxGui.h; path = "../../third-party/openFrameworks/addons/ofxGui/src/ofxGui.h"; sourceTree = SOURCE_ROOT; };
+		497776A51C72F4BD00EEE078 /* plotter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = plotter.h; sourceTree = "<group>"; };
 		498E8A1B1C600A9F0007F149 /* user_audio_beat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = user_audio_beat.h; sourceTree = "<group>"; };
 		4C42376EF0C93B60AB080532 /* ofxBaseGui.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = ofxBaseGui.h; path = "../../third-party/openFrameworks/addons/ofxGui/src/ofxBaseGui.h"; sourceTree = SOURCE_ROOT; };
 		5939D84F8D015C2971814643 /* user.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 30; name = user.h; path = src/user.h; sourceTree = SOURCE_ROOT; };
@@ -197,6 +198,7 @@
 		E4B69E1C0A3A1BDC003C02F2 /* src */ = {
 			isa = PBXGroup;
 			children = (
+				497776A51C72F4BD00EEE078 /* plotter.h */,
 				498E8A1B1C600A9F0007F149 /* user_audio_beat.h */,
 				E4B69E1D0A3A1BDC003C02F2 /* main.cpp */,
 				E4B69E1E0A3A1BDC003C02F2 /* ofApp.cpp */,

--- a/Xcode/SmartSensors/src/ofApp.cpp
+++ b/Xcode/SmartSensors/src/ofApp.cpp
@@ -127,8 +127,7 @@ void ofApp::setup() {
     for (int i = 0; i < kNumMaxLabels_; i++) {
         uint32_t label_dim = istream_->getNumOutputDimensions();
         Plotter plot;
-        plot.setup(kBufferSize_, label_dim, "Label" + std::to_string(i + 1));
-        plot.setDrawInfoText(false);
+        plot.setup(label_dim, "Label" + std::to_string(i + 1));
         plot.setColorPalette(color_palette.generate(label_dim));
         plot_samples_.push_back(plot);
         plot_sample_indices_.push_back(-1);
@@ -141,15 +140,18 @@ void ofApp::setup() {
 
         ofxButton *delete_button = new ofxButton();
         gui->add(delete_button->setup("delete", 80, 16));
-        delete_button->addListener(listener, &TrainingSampleGuiListener::deleteButtonPressed);
+        delete_button->addListener(listener,
+                                   &TrainingSampleGuiListener::deleteButtonPressed);
 
         ofxButton *trim_button = new ofxButton();
         gui->add(trim_button->setup("trim", 80, 16));
-        trim_button->addListener(listener, &TrainingSampleGuiListener::trimButtonPressed);
+        trim_button->addListener(listener,
+                                 &TrainingSampleGuiListener::trimButtonPressed);
 
         ofxButton *relable_button = new ofxButton();
         gui->add(relable_button->setup("re-label", 80, 16));
-        relable_button->addListener(listener, &TrainingSampleGuiListener::relabelButtonPressed);
+        relable_button->addListener(listener,
+                                    &TrainingSampleGuiListener::relabelButtonPressed);
 
         training_sample_guis_.push_back(gui);
     }
@@ -234,7 +236,28 @@ void ofApp::deleteTrainingSample(int num) {
 }
 
 void ofApp::trimTrainingSample(int num) {
-    ofLog(OF_LOG_NOTICE) << "Trimming sample " << num;
+    int label = num + 1;
+    TimeSeriesClassificationData data = training_data_.getClassData(label);
+    training_data_.eraseAllSamplesWithClassLabel(label);
+
+    pair<uint32_t, uint32_t> selection = plot_samples_[num].getSelection();
+    for (int i = 0; i < data.getNumSamples(); i++) {
+        if (i == plot_sample_indices_[num]) {
+            GRT::MatrixDouble sample = data[i].getData();
+            GRT::MatrixDouble new_sample;
+
+            assert(selection.second - selection.first < sample.getNumRows());
+            for (int row = selection.first; row < selection.second; row++) {
+                new_sample.push_back(sample.getRowVector(row));
+            }
+            training_data_.addSample(label, new_sample);
+            plot_samples_[num].setData(new_sample);
+        } else {
+            training_data_.addSample(label, data[i].getData());
+        }
+    }
+
+    should_save_training_data_ = true;
 }
 
 void ofApp::relabelTrainingSample(int num) {
@@ -396,16 +419,8 @@ void ofApp::drawTrainingInfo() {
     // 2. Draw samples
     // Currently we support kNumMaxLabels_ labels
     uint32_t width = stage_width / kNumMaxLabels_;
-    float minY = plot_samples_[0].getRanges().first;
-    float maxY = plot_samples_[0].getRanges().second;
-    for (int i = 1; i < kNumMaxLabels_; i++) {
-        if (plot_samples_[i].getRanges().first < minY) {
-            minY = plot_samples_[i].getRanges().first;
-        }
-        if (plot_samples_[i].getRanges().second > maxY) {
-            maxY = plot_samples_[i].getRanges().second;
-        }
-    }
+    float minY = plot_inputs_.getRanges().first;
+    float maxY = plot_inputs_.getRanges().second;
     auto class_tracker = training_data_.getClassTracker();
     for (int i = 0; i < kNumMaxLabels_; i++) {
         int label = i + 1;

--- a/Xcode/SmartSensors/src/ofApp.h
+++ b/Xcode/SmartSensors/src/ofApp.h
@@ -13,6 +13,7 @@
 
 // custom
 #include "istream.h"
+#include "plotter.h"
 
 class ofApp : public ofBaseApp {
   public:
@@ -85,11 +86,15 @@ class ofApp : public ofBaseApp {
     ofxGrtTimeseriesPlot plot_inputs_;
     vector<ofxGrtTimeseriesPlot> plot_pre_processed_;
     vector<vector<ofxGrtTimeseriesPlot>> plot_features_;
-    vector<ofxGrtTimeseriesPlot> plot_samples_;
+    vector<Plotter> plot_samples_;
     vector<std::string> plot_samples_info_;
     ofxGrtTimeseriesPlot plot_prediction_;
     vector<int> plot_sample_indices_; // the index of the currently plotted sample for each class label
     vector<pair<ofRectangle, ofRectangle>> plot_sample_button_locations_;
+
+    void onPlotRangeSelected(Plotter::CallbackArgs arg) {
+        ofLog() << arg.data;
+    }
 
     // Panel for storing and loading pipeline.
     ofxPanel gui_;
@@ -102,7 +107,7 @@ class ofApp : public ofBaseApp {
     void saveTrainingData();
     ofxButton load_training_data_button_;
     void loadTrainingData();
-    
+
     vector<ofxPanel *> training_sample_guis_;
     void deleteTrainingSample(int num);
     void trimTrainingSample(int num);
@@ -113,7 +118,7 @@ class ofApp : public ofBaseApp {
 
     // Prompts to ask the user to save the training data if changed.
     bool should_save_training_data_;
-    
+
     friend class TrainingSampleGuiListener;
 };
 

--- a/Xcode/SmartSensors/src/plotter.h
+++ b/Xcode/SmartSensors/src/plotter.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "ofxGrt.h"
+
+// The plotter class extends ofxGrtTimeseriesPlot and manages user-input to
+// support interactive operations over time-series data.
+class Plotter : public ofxGrtTimeseriesPlot {
+  public:
+    Plotter() : x_start_(0), x_end_(0), range_selected_callback_(nullptr) {
+    }
+
+    bool draw(uint32_t x, uint32_t y, uint32_t w, uint32_t h) {
+        x_ = x;
+        y_ = y;
+        w_ = w;
+        h_ = h;
+        ofxGrtTimeseriesPlot::draw(x, y, w, h);
+    }
+
+    struct CallbackArgs {
+        uint32_t start;
+        uint32_t end;
+        void* data;
+    };
+
+    typedef std::function<void(CallbackArgs)> onRangeSelectedCallback;
+
+    void onRangeSelected(const onRangeSelectedCallback& cb, void* data) {
+        range_selected_callback_ = cb;
+        callback_data_ = data;
+        ofAddListener(ofEvents().mousePressed, this, &Plotter::startSelection);
+        ofAddListener(ofEvents().mouseReleased, this, &Plotter::endSelection);
+    }
+
+    template<typename T1, typename arg, class T>
+    void onRangeSelected(T1* owner, void (T::*listenerMethod)(arg), void* data) {
+        using namespace std::placeholders;
+        onRangeSelected(std::bind(listenerMethod, owner, _1), data);
+    }
+
+  private:
+    void startSelection(ofMouseEventArgs& arg) {
+        if (x_ <= arg.x && arg.x <= x_ + w_ &&
+            y_ <= arg.y && arg.y <= y_ + h_) {
+            x_start_ = arg.x;
+        }
+    }
+
+    void endSelection(ofMouseEventArgs& arg) {
+        if (x_ <= arg.x && arg.x <= x_ + w_
+            && y_ <= arg.y && arg.y <= y_ + h_) {
+            x_end_ = arg.x;
+            ofLog() << "Area selected: [" << x_start_ << ", " << x_end_ << "]";
+            if (range_selected_callback_ != nullptr) {
+                CallbackArgs args {
+                    .start = x_start_,
+                    .end = x_end_,
+                    .data = callback_data_,
+                };
+                range_selected_callback_(args);
+            }
+        }
+    }
+
+    uint32_t x_;
+    uint32_t y_;
+    uint32_t w_;
+    uint32_t h_;
+    uint32_t x_start_;
+    uint32_t x_end_;
+
+    onRangeSelectedCallback range_selected_callback_;
+    void* callback_data_;
+};


### PR DESCRIPTION
The initial attempt of using `ofxGrtTimeseriesPlot` failed because we are not plotting time-series for samples. The circular buffer inside `ofxGrtTimeseriesPlot` makes the implementation challenge.

This pull request includes a plotter class that borrows the API (and part of the implementation) from `ofxGrtTimeseriesPlot` but uses `MatrixDouble`. This makes trimming data easy.

This PR also fixes a couple of issues:
- Trimming, https://github.com/damellis/sensors/issues/30
- Scale x-axis, https://github.com/damellis/sensors/issues/39
- x-axis Range, https://github.com/damellis/sensors/issues/40